### PR TITLE
fix: bad screenshot orientation on Android 12

### DIFF
--- a/app/src/main/java/ink/mol/droidcast_raw/AnyRequestCallback.kt
+++ b/app/src/main/java/ink/mol/droidcast_raw/AnyRequestCallback.kt
@@ -55,17 +55,21 @@ class AnyRequestCallback : HttpServerRequestCallback {
     }
 
     private fun getScreenImageInBytes(
-        destWidth: Int,
-        destHeight: Int
+        width: Int,
+        height: Int
     ): ByteArray {
-        var bitmap: Bitmap? = ScreenCaptorUtils.screenshot(destWidth, destHeight)
-        Log.i("DroidCast_raw_log", "Bitmap generated with resolution $destWidth:$destHeight")
+        var destWidth = width
+        var destHeight = height
 
-        when (displayUtil?.getScreenRotation()) {
-            1 -> bitmap = bitmap.let { displayUtil?.rotateBitmap(bitmap!!, -90f) }!!
-            2 -> bitmap = bitmap.let { displayUtil?.rotateBitmap(bitmap!!, 90f) }!!
-            3 -> bitmap = bitmap.let { displayUtil?.rotateBitmap(bitmap!!, 180f) }!!
+        val screenRotation: Int? = displayUtil?.getScreenRotation()
+        if (screenRotation != null && screenRotation != 0 && screenRotation != 2) { // not portrait
+            val tmp = destWidth
+            destWidth = destHeight
+            destHeight = tmp
         }
+
+        val bitmap: Bitmap? = ScreenCaptorUtils.screenshot(destWidth, destHeight)
+        Log.i("DroidCast_raw_log", "Bitmap generated with resolution $destWidth:$destHeight")
 
         val buffer = ByteBuffer.allocate((destWidth.times(destHeight)) * 2)
         bitmap!!.copy(Bitmap.Config.RGB_565, false)?.copyPixelsToBuffer(buffer)

--- a/app/src/main/java/ink/mol/droidcast_raw/AnyRequestCallbackPreview.kt
+++ b/app/src/main/java/ink/mol/droidcast_raw/AnyRequestCallbackPreview.kt
@@ -54,17 +54,21 @@ class AnyRequestCallbackPreview : HttpServerRequestCallback {
     }
 
     private fun getScreenImage(
-        destWidth: Int,
-        destHeight: Int
+        width: Int,
+        height: Int
     ): ByteArrayOutputStream {
-        var bitmap: Bitmap? = ScreenCaptorUtils.screenshot(destWidth, destHeight)
-        Log.i("DroidCast_raw_log", "Bitmap generated with resolution $destWidth:$destHeight")
+        var destWidth = width
+        var destHeight = height
 
-        when (displayUtil?.getScreenRotation()) {
-            1 -> bitmap = bitmap.let { displayUtil?.rotateBitmap(bitmap!!, -90f) }!!
-            2 -> bitmap = bitmap.let { displayUtil?.rotateBitmap(bitmap!!, 90f) }!!
-            3 -> bitmap = bitmap.let { displayUtil?.rotateBitmap(bitmap!!, 180f) }!!
+        val screenRotation: Int? = displayUtil?.getScreenRotation()
+        if (screenRotation != null && screenRotation != 0 && screenRotation != 2) { // not portrait
+            val tmp = destWidth
+            destWidth = destHeight
+            destHeight = tmp
         }
+
+        val bitmap: Bitmap? = ScreenCaptorUtils.screenshot(destWidth, destHeight)
+        Log.i("DroidCast_raw_log", "Bitmap generated with resolution $destWidth:$destHeight")
 
         stream = ByteArrayOutputStream()
         bitmap!!.compress(Bitmap.CompressFormat.PNG, 100, stream)

--- a/app/src/main/java/ink/mol/droidcast_raw/DisplayUtil.kt
+++ b/app/src/main/java/ink/mol/droidcast_raw/DisplayUtil.kt
@@ -2,8 +2,6 @@ package ink.mol.droidcast_raw
 
 import android.annotation.SuppressLint
 import android.content.Context
-import android.graphics.Bitmap
-import android.graphics.Matrix
 import android.graphics.Point
 import android.os.IBinder
 import android.util.Log
@@ -55,13 +53,5 @@ class DisplayUtil {
 //        println(">>> Screen rotation: $rotation")
         Log.i("DroidCast_raw_log", ">>> Screen rotation: $rotation")
         return rotation
-    }
-
-    fun rotateBitmap(bitmap: Bitmap, degree: Float): Bitmap {
-        val matrix = Matrix()
-        matrix.postRotate(degree)
-        return Bitmap.createBitmap(
-            bitmap, 0, 0, bitmap.width, bitmap.height, matrix, true
-        )
     }
 }


### PR DESCRIPTION
Fixed #3.

Porting code from rayworks/DroidCast#16 which fixed #3.

I only tested on my [Redroid 12 container](https://github.com/remote-android/redroid-doc) (which is running Android 12) with [AzurLaneAutoScript](https://github.com/LmeSzinc/AzurLaneAutoScript), and it works fine. Maybe this patch needs to be tested on more devices/platforms to ensure it will not screw up anything else.