### PR TITLE
Pass buffer to http response directly

### DIFF
--- a/app/src/main/java/ink/mol/droidcast_raw/AnyRequestCallback.kt
+++ b/app/src/main/java/ink/mol/droidcast_raw/AnyRequestCallback.kt
@@ -39,9 +39,9 @@ class AnyRequestCallback : HttpServerRequestCallback {
             val destWidth: Int = Main.getWidth()
             val destHeight: Int = Main.getHeight()
 
-            val bytes: ByteArray = getScreenImageInBytes(destWidth, destHeight)
+            val buffer: ByteBuffer = getScreenImageInByteBuffer(destWidth, destHeight)
 
-            response?.send("application/octet-stream", bytes)
+            response?.send("application/octet-stream", buffer)
         } catch (e: Exception) {
             e.printStackTrace()
             response?.code(500)
@@ -54,10 +54,10 @@ class AnyRequestCallback : HttpServerRequestCallback {
         }
     }
 
-    private fun getScreenImageInBytes(
+    private fun getScreenImageInByteBuffer(
         width: Int,
         height: Int
-    ): ByteArray {
+    ): ByteBuffer {
         var destWidth = width
         var destHeight = height
 
@@ -74,7 +74,8 @@ class AnyRequestCallback : HttpServerRequestCallback {
         val buffer = ByteBuffer.allocate((destWidth.times(destHeight)) * 2)
         bitmap!!.copy(Bitmap.Config.RGB_565, false)?.copyPixelsToBuffer(buffer)
         bitmap.recycle()
+        buffer.flip()
 
-        return buffer.array()
+        return buffer
     }
 }


### PR DESCRIPTION
减少 5ms 左右响应时间，但是复现不是很稳定，ALAS 内还是 20ms+，有条件希望能找各种环境试试，以及试试 direct buffer （我本地似乎没有任何区别）

改动前

```
$ oha -c 1 -n 500 http://localhost:53517/screenshot
Summary:
  Success rate: 100.00%
  Total:        8.2593 secs
  Slowest:      0.0296 secs
  Fastest:      0.0131 secs
  Average:      0.0165 secs
  Requests/sec: 60.5379

  Total data:   878.91 MiB
  Size/request: 1.76 MiB
  Size/sec:     106.41 MiB

Response time histogram:
  0.013 [1]   |
  0.015 [23]  |■■■
  0.016 [229] |■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■
  0.018 [207] |■■■■■■■■■■■■■■■■■■■■■■■■■■■■
  0.020 [29]  |■■■■
  0.021 [7]   |
  0.023 [2]   |
  0.025 [0]   |
  0.026 [0]   |
  0.028 [1]   |
  0.030 [1]   |

Response time distribution:
  10.00% in 0.0151 secs
  25.00% in 0.0157 secs
  50.00% in 0.0164 secs
  75.00% in 0.0171 secs
  90.00% in 0.0178 secs
  95.00% in 0.0187 secs
  99.00% in 0.0212 secs
  99.90% in 0.0296 secs
  99.99% in 0.0296 secs


Details (average, fastest, slowest):
  DNS+dialup:   0.0002 secs, 0.0002 secs, 0.0002 secs
  DNS-lookup:   0.0000 secs, 0.0000 secs, 0.0000 secs

Status code distribution:
  [200] 500 responses
```
改动后
```
$ oha -c 1 -n 500 http://localhost:53517/screenshot
Summary:
  Success rate: 100.00%
  Total:        4.7167 secs
  Slowest:      0.0208 secs
  Fastest:      0.0075 secs
  Average:      0.0094 secs
  Requests/sec: 106.0066

  Total data:   0 B
  Size/request: 0 B
  Size/sec:     0 B

Response time histogram:
  0.007 [1]   |
  0.009 [175] |■■■■■■■■■■■■■■■■■■■■■■■■■■
  0.010 [209] |■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■
  0.011 [88]  |■■■■■■■■■■■■■
  0.013 [20]  |■■■
  0.014 [1]   |
  0.015 [1]   |
  0.017 [0]   |
  0.018 [0]   |
  0.019 [3]   |
  0.021 [2]   |

Response time distribution:
  10.00% in 0.0080 secs
  25.00% in 0.0084 secs
  50.00% in 0.0093 secs
  75.00% in 0.0101 secs
  90.00% in 0.0110 secs
  95.00% in 0.0115 secs
  99.00% in 0.0189 secs
  99.90% in 0.0208 secs
  99.99% in 0.0208 secs


Details (average, fastest, slowest):
  DNS+dialup:   0.0003 secs, 0.0003 secs, 0.0003 secs
  DNS-lookup:   0.0000 secs, 0.0000 secs, 0.0000 secs

Status code distribution:
  [200] 500 responses
```